### PR TITLE
Fix utility distance function names

### DIFF
--- a/server/src/prepare_data/preprocessing.py
+++ b/server/src/prepare_data/preprocessing.py
@@ -5,9 +5,9 @@ import h3
 
 from src.prepare_data.utils import copy_df
 from src.prepare_data.config import Centroids, Random, H3, FinalFeatures
-from src.prepare_data.utils import calculate_eucleadian_dist
+from src.prepare_data.utils import calculate_euclidean_dist
 from src.prepare_data.utils import calculate_haversine_dist
-from src.prepare_data.utils import calculate_avg_distance_to_resturants
+from src.prepare_data.utils import calculate_avg_distance_to_restaurants
 from src.prepare_data.utils import calculate_avg_Hdist_to_restaurants
 
 import logging
@@ -66,7 +66,7 @@ def assign_centroids(df):
     centroids_list = [c for i,c in centroids.iterrows()]
     for i,obs in df.iterrows():
         # Estimate error
-        all_errors = [calculate_eucleadian_dist(centroid['lat'],
+        all_errors = [calculate_euclidean_dist(centroid['lat'],
                                 centroid['lon'],
                                 obs['courier_lat'],
                                 obs['courier_lon']) for centroid in centroids_list]
@@ -87,9 +87,12 @@ def add_distance_columns(df:pd.DataFrame):
     
     restaurants_ids = prepare_restaurants_ids(df)
     logger.info('ADDING 4 DISTANCE COLUMNS...')
-    df['dist_to_restaurant'] = calculate_eucleadian_dist(df.courier_lat, df.courier_lon, df.restaurant_lat, df.restaurant_lon)
+    df['dist_to_restaurant'] = calculate_euclidean_dist(df.courier_lat, df.courier_lon, df.restaurant_lat, df.restaurant_lon)
     logger.info('EUCLEADIAN DISTANCE ADDED...')
-    df['avg_dist_to_restaurants'] = [calculate_avg_distance_to_resturants(lat, lon, restaurants_ids) for lat,lon in zip(df.courier_lat, df.courier_lon)]
+    df['avg_dist_to_restaurants'] = [
+        calculate_avg_distance_to_restaurants(lat, lon, restaurants_ids)
+        for lat, lon in zip(df.courier_lat, df.courier_lon)
+    ]
     logger.info('AVG DISTANCE ADDED...')
     df['Hdist_to_restaurant'] = calculate_haversine_dist(df.courier_lat.tolist(), df.courier_lon.tolist(), df.restaurant_lat.tolist(), df.restaurant_lon.tolist())
     logger.info('HDIST ADDED...')

--- a/server/src/prepare_data/utils.py
+++ b/server/src/prepare_data/utils.py
@@ -9,15 +9,21 @@ def copy_df(df:pd.DataFrame):
 
     return df.copy()
 
-def calculate_eucleadian_dist(p1x:float, p1y:float, p2x:float, p2y:float):
-    p1 = (p2x - p1x)**2
-    p2 = (p2y - p1y)**2
+def calculate_euclidean_dist(p1x: float, p1y: float, p2x: float, p2y: float):
+    p1 = (p2x - p1x) ** 2
+    p2 = (p2y - p1y) ** 2
     dist = np.sqrt(p1 + p2)
     return dist.tolist() if isinstance(p1x, collections.abc.Sequence) else dist
 
-def calculate_avg_distance_to_resturants(courier_lat:float, courier_lon:float, restaurants_ids:dict):
-    return np.mean([calculate_eucleadian_dist(v['lat'], v['lon'], \
-        courier_lat, courier_lon) for v in restaurants_ids.values()])
+def calculate_avg_distance_to_restaurants(
+    courier_lat: float, courier_lon: float, restaurants_ids: dict
+):
+    return np.mean(
+        [
+            calculate_euclidean_dist(v["lat"], v["lon"], courier_lat, courier_lon)
+            for v in restaurants_ids.values()
+        ]
+    )
 
 def calculate_haversine_dist(lat1:float, lon1:float, lat2:float, lon2:float, radians_metric = "kilometers"):
    

--- a/src/prepare_data/preprocessing.py
+++ b/src/prepare_data/preprocessing.py
@@ -5,9 +5,9 @@ import h3
 
 from src.prepare_data.utils import copy_df
 from src.prepare_data.config import Centroids, Random, H3, FinalFeatures
-from src.prepare_data.utils import calculate_eucleadian_dist
+from src.prepare_data.utils import calculate_euclidean_dist
 from src.prepare_data.utils import calculate_haversine_dist
-from src.prepare_data.utils import calculate_avg_distance_to_resturants
+from src.prepare_data.utils import calculate_avg_distance_to_restaurants
 from src.prepare_data.utils import calculate_avg_Hdist_to_restaurants
 
 import logging
@@ -66,7 +66,7 @@ def assign_centroids(df):
     centroids_list = [c for i,c in centroids.iterrows()]
     for i,obs in df.iterrows():
         # Estimate error
-        all_errors = [calculate_eucleadian_dist(centroid['lat'],
+        all_errors = [calculate_euclidean_dist(centroid['lat'],
                                 centroid['lon'],
                                 obs['courier_lat'],
                                 obs['courier_lon']) for centroid in centroids_list]
@@ -87,9 +87,12 @@ def add_distance_columns(df:pd.DataFrame):
     
     restaurants_ids = prepare_restaurants_ids(df)
     logger.info('ADDING 4 DISTANCE COLUMNS...')
-    df['dist_to_restaurant'] = calculate_eucleadian_dist(df.courier_lat, df.courier_lon, df.restaurant_lat, df.restaurant_lon)
+    df['dist_to_restaurant'] = calculate_euclidean_dist(df.courier_lat, df.courier_lon, df.restaurant_lat, df.restaurant_lon)
     logger.info('EUCLEADIAN DISTANCE ADDED...')
-    df['avg_dist_to_restaurants'] = [calculate_avg_distance_to_resturants(lat, lon, restaurants_ids) for lat,lon in zip(df.courier_lat, df.courier_lon)]
+    df['avg_dist_to_restaurants'] = [
+        calculate_avg_distance_to_restaurants(lat, lon, restaurants_ids)
+        for lat, lon in zip(df.courier_lat, df.courier_lon)
+    ]
     logger.info('AVG DISTANCE ADDED...')
     df['Hdist_to_restaurant'] = calculate_haversine_dist(df.courier_lat.tolist(), df.courier_lon.tolist(), df.restaurant_lat.tolist(), df.restaurant_lon.tolist())
     logger.info('HDIST ADDED...')

--- a/src/prepare_data/utils.py
+++ b/src/prepare_data/utils.py
@@ -9,15 +9,21 @@ def copy_df(df:pd.DataFrame):
 
     return df.copy()
 
-def calculate_eucleadian_dist(p1x:float, p1y:float, p2x:float, p2y:float):
-    p1 = (p2x - p1x)**2
-    p2 = (p2y - p1y)**2
+def calculate_euclidean_dist(p1x: float, p1y: float, p2x: float, p2y: float):
+    p1 = (p2x - p1x) ** 2
+    p2 = (p2y - p1y) ** 2
     dist = np.sqrt(p1 + p2)
     return dist.tolist() if isinstance(p1x, collections.abc.Sequence) else dist
 
-def calculate_avg_distance_to_resturants(courier_lat:float, courier_lon:float, restaurants_ids:dict):
-    return np.mean([calculate_eucleadian_dist(v['lat'], v['lon'], \
-        courier_lat, courier_lon) for v in restaurants_ids.values()])
+def calculate_avg_distance_to_restaurants(
+    courier_lat: float, courier_lon: float, restaurants_ids: dict
+):
+    return np.mean(
+        [
+            calculate_euclidean_dist(v["lat"], v["lon"], courier_lat, courier_lon)
+            for v in restaurants_ids.values()
+        ]
+    )
 
 def calculate_haversine_dist(lat1:float, lon1:float, lat2:float, lon2:float, radians_metric = "kilometers"):
    


### PR DESCRIPTION
## Summary
- rename misspelled distance helpers to `calculate_euclidean_dist` and `calculate_avg_distance_to_restaurants`
- update preprocessing imports and usage in both training and server modules

## Testing
- `python -m py_compile src/prepare_data/utils.py src/prepare_data/preprocessing.py server/src/prepare_data/utils.py server/src/prepare_data/preprocessing.py`
