### PR TITLE
Fix target default and ensure 1D y

### DIFF
--- a/server/src/train/model.py
+++ b/server/src/train/model.py
@@ -24,7 +24,7 @@ class BusynessEstimation(object):
     def __init__(self,
                  # train_df:pd.DataFrame=None,
                  test_df:pd.DataFrame=None,
-                 target:str=Data.target,
+                 target:str=Data.target[0],
                  random_state:int=RF.regr_random_state          
                 ):
 
@@ -79,7 +79,7 @@ class BusynessEstimation(object):
     def fit(self, X, y=None):
 
         self.X_train = X.copy()
-        self.y_train = y.copy()
+        self.y_train = y.squeeze().copy()
         
         self.fit_and_evaluate_model()
         

--- a/src/train/model.py
+++ b/src/train/model.py
@@ -23,7 +23,7 @@ class BusynessEstimation(object):
     def __init__(self,
                  # train_df:pd.DataFrame=None,
                  test_df: pd.DataFrame = None,
-                 target: str = Data.target,
+                 target: str = Data.target[0],
                  random_state: int = RF.regr_random_state
                  ):
 
@@ -78,7 +78,7 @@ class BusynessEstimation(object):
     def fit(self, X, y=None):
 
         self.X_train = X.copy()
-        self.y_train = y.copy()
+        self.y_train = y.squeeze().copy()
 
         self.fit_and_evaluate_model()
 


### PR DESCRIPTION
## Summary
- Ensure BusynessEstimation uses a string target column name
- Squeeze `y` in `fit` so training labels are 1-D

## Testing
- `pytest -q`
- `python - <<'PY'
import pandas as pd
import numpy as np
from src.train.model import BusynessEstimation
from src.train.config import Data
n=50
X=pd.DataFrame(np.random.randn(n,len(Data.features)),columns=Data.features)
y=pd.Series(np.random.randn(n),name=Data.target[0])
test_df=pd.concat([X.iloc[:10].reset_index(drop=True),y.iloc[:10].reset_index(drop=True)],axis=1)
model=BusynessEstimation(test_df)
model.fit(X,y)
print(model.scores)
PY`
