### PR TITLE
Clarify restaurant mapping docstring

### DIFF
--- a/server/src/prepare_data/preprocessing.py
+++ b/server/src/prepare_data/preprocessing.py
@@ -21,7 +21,13 @@ handler.setFormatter(formatter)
 logger.handlers = [handler]
 
 def prepare_restaurants_ids(df:pd.DataFrame) -> dict:
-    """Add resturant id column"""
+    """Build mapping of restaurant coordinates to unique IDs.
+
+    The DataFrame is scanned for unique combinations of ``restaurant_lat`` and
+    ``restaurant_lon``.  Each distinct coordinate pair receives an integer
+    identifier and is stored in a dictionary keyed by ``"<lat>_<lon>"``.  The
+    mapping with coordinates and their assigned ID is then returned.
+    """
     logger.info('PREPARING RESURANT IDs...')
     
     #unique restaurants

--- a/src/prepare_data/preprocessing.py
+++ b/src/prepare_data/preprocessing.py
@@ -21,7 +21,14 @@ handler.setFormatter(formatter)
 logger.handlers = [handler]
 
 def prepare_restaurants_ids(df:pd.DataFrame) -> dict:
-    """Add resturant id column"""
+    """Build mapping of restaurant coordinates to unique IDs.
+
+    The DataFrame is scanned for unique combinations of ``restaurant_lat`` and
+    ``restaurant_lon``.  Each unique coordinate pair is assigned an integer
+    identifier and stored in a dictionary keyed by ``"<lat>_<lon>"``.  The
+    resulting mapping, containing the coordinates and their associated ID, is
+    returned.
+    """
     logger.info('PREPARING RESURANT IDs...')
     
     #unique restaurants


### PR DESCRIPTION
## Summary
- clarify restaurant mapping function docstring in training and server modules

## Testing
- `pytest`
- `pre-commit run --files src/prepare_data/preprocessing.py server/src/prepare_data/preprocessing.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891749dd810832f9272922dbadcb215