### PR TITLE
Add linting and type-check commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,16 @@ install:
 	bash run.sh install
 
 lint:
-	bash run.sh lint
+        bash run.sh lint
 
 lint-ci:
-	bash run.sh lint:ci
+        bash run.sh lint:ci
+
+lint-ruff:
+        bash run.sh lint:ruff
+
+type-check:
+        bash run.sh type-check
 
 publish-prod:
 	bash run.sh publish:prod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,7 @@ line-length = 119
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["E402"]
 "path/to/file.py" = ["E402"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true

--- a/run.sh
+++ b/run.sh
@@ -22,6 +22,17 @@ function lint:ci {
     SKIP=no-commit-to-branch pre-commit run --all-files
 }
 
+# run the Ruff linter across source and test modules
+function lint:ruff {
+    ruff check "$THIS_DIR/src" "$THIS_DIR/server/src" "$THIS_DIR/test"
+}
+
+# static type checking with mypy
+function type-check {
+    mypy --ignore-missing-imports --no-strict-optional --explicit-package-bases \
+        "$THIS_DIR/src" "$THIS_DIR/server/src"
+}
+
 # execute tests that are not marked as `slow`
 function test:quick {
     run-tests -m "not slow" ${@:-"$THIS_DIR/tests/"}


### PR DESCRIPTION
## Summary
- add dedicated Ruff lint and mypy type-check helpers
- expose lint-ruff and type-check targets in Makefile
- configure mypy in pyproject

## Testing
- `bash run.sh lint:ruff` *(fails: 22 errors)*
- `bash run.sh type-check` *(fails: 16 errors)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68916e72706c832f92fe95eaa04409d6