### PR TITLE
Remove explicit kfp-pipeline-spec dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,6 @@ h3==3.7.6
 idna==3.6
 joblib==1.3.2
 kfp==2.6.0
-kfp-pipeline-spec==0.3.0
 kfp-server-api==2.0.5
 kubernetes==26.1.0
 mypy-extensions==1.0.0


### PR DESCRIPTION
## Summary
- remove direct kfp-pipeline-spec requirement to rely on kfp's bundled version

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `pre-commit run --files requirements.txt` *(fails: command not found / cannot install due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6891891cee84832f9231229cddd77512