### PR TITLE
feat: load credentials from env variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .env
 .venv
+.keys/
 gs_remote/
 data/
 assignment/

--- a/vertex_ai_pipeline.ipynb
+++ b/vertex_ai_pipeline.ipynb
@@ -101,7 +101,8 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "os.environ[\"GOOGLE_APPLICATION_CREDENTIALS\"] = \".keys/id-410816-74ba6ea719a9.json\""
+    "if \"GOOGLE_APPLICATION_CREDENTIALS\" not in os.environ:\n",
+    "    os.environ[\"GOOGLE_APPLICATION_CREDENTIALS\"] = input(\"Enter path to Google Cloud service account key JSON: \")\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- load GOOGLE_APPLICATION_CREDENTIALS from env var or prompt instead of hardcoding path
- ignore local `.keys/` credential directory

## Testing
- `pre-commit run --files vertex_ai_pipeline.ipynb .gitignore` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68922fb93764832fb075cdf6a162f199