### PR TITLE
Parameterize server docker scripts with PROJECT_ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ METRIC_PATH=/ml/metrics
 METRIC_FILE=model_performance.json
 GCP_SECRET_ACCESS_KEY=__your_aws_access_key__
 GCP_SECRET_ACCESS_KEY_ID=__your_aws_secret_key__
+PROJECT_ID=your-project-id

--- a/server/sh_0.1_docker_build.sh
+++ b/server/sh_0.1_docker_build.sh
@@ -1,9 +1,13 @@
-#!/bin/bash     
-PROJECT_ID="skip-the-dishes-410816"
+#!/bin/bash
+
+# Allow PROJECT_ID to be provided via the environment. Default to a placeholder
+# value so the script can be run locally without modification.
+PROJECT_ID=${PROJECT_ID:-your-project-id}
 REGION="us-central1"
 REPOSITORY="regionbusyness"
 IMAGE='serving'
 IMAGE_TAG='serving:latest'
 
-docker build -t $IMAGE .
-docker tag $IMAGE $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE_TAG
+docker build -t "$IMAGE" .
+docker tag "$IMAGE" "$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE_TAG"
+

--- a/server/sh_0.2_push_to_artifactory.sh
+++ b/server/sh_0.2_push_to_artifactory.sh
@@ -1,16 +1,20 @@
-#!/bin/bash     
-PROJECT_ID="skip-the-dishes-410816"
+#!/bin/bash
+
+# Allow PROJECT_ID to be provided via the environment. Default to a placeholder
+# value so the script can be run locally without modification.
+PROJECT_ID=${PROJECT_ID:-your-project-id}
 REGION="us-central1"
 REPOSITORY="regionbusyness"
 IMAGE_TAG='serving:latest'
 
-#Create repository in the artifact registry
-gcloud beta artifacts repositories create $REPOSITORY \
+# Create repository in the artifact registry
+gcloud beta artifacts repositories create "$REPOSITORY" \
   --repository-format=docker \
-  --location=$REGION
- 
+  --location="$REGION"
+
 # Configure Docker
-gcloud auth configure-docker $REGION-docker.pkg.dev
- 
- # Push
-docker push $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE_TAG
+gcloud auth configure-docker "$REGION-docker.pkg.dev"
+
+# Push
+docker push "$REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY/$IMAGE_TAG"
+


### PR DESCRIPTION
## Summary
- allow PROJECT_ID to be provided via the environment in server docker build/push scripts
- document PROJECT_ID in `.env.example`

## Testing
- `PATH="$(pwd)/tmp-bin:$PATH" PROJECT_ID=my-test-project bash server/sh_0.1_docker_build.sh`
- `PATH="$(pwd)/tmp-bin:$PATH" PROJECT_ID=my-test-project bash server/sh_0.2_push_to_artifactory.sh`
- `pytest`
- ⚠️ `pre-commit run --files server/sh_0.1_docker_build.sh server/sh_0.2_push_to_artifactory.sh .env.example` *(command not found and install attempt failed)*

------
https://chatgpt.com/codex/tasks/task_e_68923189427c832fabf2f98eef48ed7f