### PR TITLE
fix: read ML_BASE_URI from environment

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -27,7 +27,7 @@ class Config:
         if getenv("ML_BASE_URI") is None:
             self.exit_program("ML_BASE_URI")
         else:
-            self.ml_base_uri = ml_base_uri  # pragma: no cover
+            self.ml_base_uri = getenv("ML_BASE_URI")  # pragma: no cover
 
     def exit_program(self, env_var: str) -> None:
         """Exit the program with a helpful error message."""


### PR DESCRIPTION
## Summary
- ensure server `Config` reads ML_BASE_URI directly from environment

## Testing
- `bash run.sh lint` *(fails: pre-commit: command not found)*
- `python -m pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `python -m py_compile server/config.py`


------
https://chatgpt.com/codex/tasks/task_e_689246d1fd18832fb3f98b70e68e4c41