### PR TITLE
Add tests for preprocessing pipeline and busyness model

### DIFF
--- a/test/test_busyness_estimation.py
+++ b/test/test_busyness_estimation.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pandas as pd
+from src.train import model as model_module
+from src.train.model import BusynessEstimation
+from src.train import config
+
+
+def test_busyness_estimation_predicts(monkeypatch):
+    """BusynessEstimation trains and produces predictions on synthetic data."""
+
+    monkeypatch.setattr(
+        config.RF,
+        "best_params",
+        {"n_estimators": 5, "min_samples_leaf": 1, "max_depth": 2},
+    )
+    monkeypatch.setattr(model_module, "check_is_fitted", lambda estimator: None)
+
+    X = pd.DataFrame(
+        {
+            "dist_to_restaurant": [0.1, 0.2, 0.3, 0.4, 0.5],
+            "Hdist_to_restaurant": [1, 2, 3, 4, 5],
+            "avg_Hdist_to_restaurants": [1.5, 2.5, 3.5, 4.5, 5.5],
+            "date_day_number": [1, 1, 1, 1, 1],
+            "restaurant_id": [0, 1, 2, 3, 4],
+            "Five_Clusters_embedding": [0, 1, 2, 3, 4],
+            "h3_index": [0, 1, 2, 3, 4],
+            "date_hour_number": [10, 11, 12, 13, 14],
+            "restaurants_per_index": [1, 2, 3, 4, 5],
+        }
+    )
+    y = pd.Series([5, 6, 7, 8, 9], name="orders_busyness_by_h3_hour")
+
+    test_df = pd.concat([X.iloc[3:], y.iloc[3:]], axis=1)
+    model = BusynessEstimation(test_df=test_df)
+    model.fit(X.iloc[:3], y.iloc[:3])
+
+    preds = model.predict(test_df.drop("orders_busyness_by_h3_hour", axis=1))
+    assert isinstance(preds, np.ndarray)
+    assert preds.shape[0] == len(test_df)
+    assert set(model.scores.keys()) == {
+        "baseline_scores",
+        "train_scores",
+        "test_scores",
+    }

--- a/test/test_preprocessing_pipeline.py
+++ b/test/test_preprocessing_pipeline.py
@@ -1,0 +1,47 @@
+import numpy as np
+import pandas as pd
+from src.prepare_data import preprocessing, utils
+from src.prepare_data.config import FinalFeatures
+
+
+def test_data_preprocessing_pipeline(monkeypatch):
+    """Data preprocessing pipeline produces expected features on synthetic data."""
+
+    def euclidean(p1x, p1y, p2x, p2y):
+        p1x_arr = np.asarray(p1x, dtype=float)
+        p1y_arr = np.asarray(p1y, dtype=float)
+        p2x_arr = np.asarray(p2x, dtype=float)
+        p2y_arr = np.asarray(p2y, dtype=float)
+        dist = np.sqrt((p2x_arr - p1x_arr) ** 2 + (p2y_arr - p1y_arr) ** 2)
+        if dist.ndim == 0:
+            return float(dist)
+        return dist.tolist()
+
+    monkeypatch.setattr(utils, "calculate_euclidean_dist", euclidean)
+    monkeypatch.setattr(preprocessing, "calculate_euclidean_dist", euclidean)
+
+    n = 5
+    df = pd.DataFrame(
+        {
+            "courier_lat": [0.0] * n,
+            "courier_lon": [0.0] * n,
+            "restaurant_lat": [0, 0.01, 0.02, 0.03, 0.04],
+            "restaurant_lon": [0.01, 0.02, 0.03, 0.04, 0.05],
+            "courier_location_timestamp": pd.date_range(
+                "2024-01-01 10:00:00", periods=n, freq="min"
+            ),
+            "order_created_timestamp": pd.date_range(
+                "2024-01-01 09:55:00", periods=n, freq="min"
+            ),
+        }
+    )
+
+    processed = preprocessing.data_preprocessing_pipeline(df)
+
+    expected_cols = FinalFeatures.features + FinalFeatures.target
+    assert list(processed.columns) == expected_cols
+    assert processed["orders_busyness_by_h3_hour"].nunique() == 1
+    assert processed["orders_busyness_by_h3_hour"].iloc[0] == n
+    assert processed["restaurants_per_index"].nunique() == 1
+    assert processed["restaurants_per_index"].iloc[0] == n
+    assert processed.isna().sum().sum() == 0


### PR DESCRIPTION
## Summary
- add synthetic-data test for data_preprocessing_pipeline ensuring expected features and counts
- verify BusynessEstimation trains and predicts on small datasets without external dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892470c6e38832f92d155125250d6b4