### PR TITLE
Remove duplicate Flask app initialization

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -25,9 +25,6 @@ logger.info(f"MODEL PATH: {AIP_STORAGE_URI}")
 
 MODEL_PATH = "model/model.pickle"
 
-# Creation of the Flask app
-app = Flask(__name__)
-
 
 def decode_gcs_url(url: str) -> Tuple[str, str]:
     """Split a Google Cloud Storage path into bucket and blob."""


### PR DESCRIPTION
## Summary
- remove redundant Flask app creation so routes share a single instance

## Testing
- `pytest`
- `pre-commit run --files server/app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892527fcff4832fbe740e3ad80ee0be