### PR TITLE
Remove interactive credential prompt from Vertex AI pipeline

### DIFF
--- a/vertex_ai_pipeline.ipynb
+++ b/vertex_ai_pipeline.ipynb
@@ -100,9 +100,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "if \"GOOGLE_APPLICATION_CREDENTIALS\" not in os.environ:\n",
-    "    os.environ[\"GOOGLE_APPLICATION_CREDENTIALS\"] = input(\"Enter path to Google Cloud service account key JSON: \")\n"
+    "# Initialize Vertex AI with project and region\n",
+    "# Credentials are resolved via Application Default Credentials.\n",
+    "vertex_.init(project=PROJECT_ID, location=REGION)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- rely on Application Default Credentials for Vertex AI
- initialize Vertex AI client with project and region

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892612a264c832fad7c0ee8415072c6