### PR TITLE
Define serving container image URI for Vertex pipeline

### DIFF
--- a/vertex_ai_pipeline.ipynb
+++ b/vertex_ai_pipeline.ipynb
@@ -784,6 +784,7 @@
    },
    "outputs": [],
    "source": [
+    "serving_container_image_uri = \"gcr.io/your-project/serving-image:latest\"\n",
     "\n",
     "\n",
     "@dsl.pipeline(\n",


### PR DESCRIPTION
## Summary
- Define `serving_container_image_uri` constant before the Vertex AI pipeline

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68926175f44c832fbd7cff5468798bbe