### PR TITLE
Remove output_component_file from components and compile separately

### DIFF
--- a/vertex_ai_pipeline.ipynb
+++ b/vertex_ai_pipeline.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "id",
    "metadata": {
     "tags": []
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "7f3bc836-0ebe-461b-9143-83f362ef5a3c",
    "metadata": {
     "tags": []
@@ -51,40 +51,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "3c35da1d-90f5-4676-98df-635ab4418784",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "gs://id-rb/pipeline_root_rb/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(PIPELINE_ROOT)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "ed5a4342-b3b1-4280-997e-cc819fd5a3e7",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "us-central1-docker.pkg.dev/id-410816/rb/training:latest\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Custom base image created using docker\n",
     "\n",
@@ -95,7 +79,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "cfed53d4",
    "metadata": {},
    "outputs": [],
@@ -107,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "9cfc7fca-561f-4ac3-8493-15bfaf28a7b5",
    "metadata": {
     "tags": []
@@ -140,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "650b8aff-5012-4ac9-b5de-b8c0179a0bbb",
    "metadata": {
     "tags": []
@@ -177,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "id": "ea94bb86-8bfe-4eb2-a5ae-064d0a66a0ab",
    "metadata": {
     "tags": []
@@ -208,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "7d247743-d89c-456d-a96e-198fb3219f24",
    "metadata": {
     "tags": []
@@ -220,138 +204,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "id": "4c966034-e9c8-4f57-b89a-b6ebfcb39f38",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>courier_id</th>\n",
-       "      <th>order_number</th>\n",
-       "      <th>courier_location_timestamp</th>\n",
-       "      <th>courier_lat</th>\n",
-       "      <th>courier_lon</th>\n",
-       "      <th>order_created_timestamp</th>\n",
-       "      <th>restaurant_lat</th>\n",
-       "      <th>restaurant_lon</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>a98737cbhoho5012hoho4b5bhoho867fhoho8475c658546d</td>\n",
-       "      <td>281289453</td>\n",
-       "      <td>2021-04-02T04:30:42.328Z</td>\n",
-       "      <td>50.484520</td>\n",
-       "      <td>-104.618876</td>\n",
-       "      <td>2021-04-02T04:20:42Z</td>\n",
-       "      <td>50.483696</td>\n",
-       "      <td>-104.614350</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>39a26fa0hohof428hoho47a4hohoa320hoho12e3d831c23a</td>\n",
-       "      <td>280949566</td>\n",
-       "      <td>2021-04-01T06:14:47.386Z</td>\n",
-       "      <td>50.442573</td>\n",
-       "      <td>-104.550463</td>\n",
-       "      <td>2021-04-01T06:05:18Z</td>\n",
-       "      <td>50.442422</td>\n",
-       "      <td>-104.550487</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>3813235ehoho7a42hoho4601hohob7eahoho799e8af5b535</td>\n",
-       "      <td>281328578</td>\n",
-       "      <td>2021-04-02T05:48:57.224Z</td>\n",
-       "      <td>50.495920</td>\n",
-       "      <td>-104.635605</td>\n",
-       "      <td>2021-04-02T05:13:26Z</td>\n",
-       "      <td>50.496595</td>\n",
-       "      <td>-104.635606</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>9f033953hohocd53hoho488ahohoaf51hohoc57943e499ed</td>\n",
-       "      <td>281317998</td>\n",
-       "      <td>2021-04-02T05:12:17.252Z</td>\n",
-       "      <td>50.449445</td>\n",
-       "      <td>-104.611521</td>\n",
-       "      <td>2021-04-02T04:59:57Z</td>\n",
-       "      <td>50.449504</td>\n",
-       "      <td>-104.611074</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>56f65bc8hohoba54hoho47dfhohoa09chohof7464b5d9848</td>\n",
-       "      <td>281314132</td>\n",
-       "      <td>2021-04-02T05:15:38.266Z</td>\n",
-       "      <td>50.495254</td>\n",
-       "      <td>-104.666383</td>\n",
-       "      <td>2021-04-02T04:54:53Z</td>\n",
-       "      <td>50.495160</td>\n",
-       "      <td>-104.665733</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                         courier_id  order_number  \\\n",
-       "0  a98737cbhoho5012hoho4b5bhoho867fhoho8475c658546d     281289453   \n",
-       "1  39a26fa0hohof428hoho47a4hohoa320hoho12e3d831c23a     280949566   \n",
-       "2  3813235ehoho7a42hoho4601hohob7eahoho799e8af5b535     281328578   \n",
-       "3  9f033953hohocd53hoho488ahohoaf51hohoc57943e499ed     281317998   \n",
-       "4  56f65bc8hohoba54hoho47dfhohoa09chohof7464b5d9848     281314132   \n",
-       "\n",
-       "  courier_location_timestamp  courier_lat  courier_lon  \\\n",
-       "0   2021-04-02T04:30:42.328Z    50.484520  -104.618876   \n",
-       "1   2021-04-01T06:14:47.386Z    50.442573  -104.550463   \n",
-       "2   2021-04-02T05:48:57.224Z    50.495920  -104.635605   \n",
-       "3   2021-04-02T05:12:17.252Z    50.449445  -104.611521   \n",
-       "4   2021-04-02T05:15:38.266Z    50.495254  -104.666383   \n",
-       "\n",
-       "  order_created_timestamp  restaurant_lat  restaurant_lon  \n",
-       "0    2021-04-02T04:20:42Z       50.483696     -104.614350  \n",
-       "1    2021-04-01T06:05:18Z       50.442422     -104.550487  \n",
-       "2    2021-04-02T05:13:26Z       50.496595     -104.635606  \n",
-       "3    2021-04-02T04:59:57Z       50.449504     -104.611074  \n",
-       "4    2021-04-02T04:54:53Z       50.495160     -104.665733  "
-      ]
-     },
-     "execution_count": 37,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "id": "66472a86",
    "metadata": {},
    "outputs": [],
@@ -362,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "id": "12723133-926e-41b5-9ad1-acd6c8fea58f",
    "metadata": {
     "tags": []
@@ -382,25 +247,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "id": "ecaced7f-0c4d-4b51-bccc-92d89c8f1bcd",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/n8/sbp8v1ys5wz6pm1xg3jkgnpm0000gn/T/ipykernel_23685/1386007704.py:1: DeprecationWarning: output_component_file parameter is deprecated and will eventually be removed. Please use `Compiler().compile()` to compile a component instead.\n",
-      "  @component(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "@component(\n",
     "    base_image=BASE_IMAGE,\n",
-    "    output_component_file=\"get_data.yaml\"\n",
     ")\n",
     "\n",
     "def get_std_data(\n",
@@ -428,25 +283,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "id": "5c58792b-d7e2-4d34-83f9-31e0d7948659",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/n8/sbp8v1ys5wz6pm1xg3jkgnpm0000gn/T/ipykernel_23685/1988278445.py:1: DeprecationWarning: output_component_file parameter is deprecated and will eventually be removed. Please use `Compiler().compile()` to compile a component instead.\n",
-      "  @component(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "@component(\n",
     "    base_image=BASE_IMAGE,\n",
-    "    output_component_file=\"preprocessing.yaml\"\n",
     ")\n",
     "\n",
     "def preprocess_std_data(\n",
@@ -474,25 +319,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "65aa16be-21e0-494c-9ac0-60cc4609aa17",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/n8/sbp8v1ys5wz6pm1xg3jkgnpm0000gn/T/ipykernel_23685/593052275.py:1: DeprecationWarning: output_component_file parameter is deprecated and will eventually be removed. Please use `Compiler().compile()` to compile a component instead.\n",
-      "  @component(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "@component(\n",
     "    base_image=BASE_IMAGE,\n",
-    "    output_component_file=\"train_test_split.yaml\",\n",
     ")\n",
     "def train_test_split(dataset_in: Input[Dataset],\n",
     "                     dataset_train: Output[Dataset],\n",
@@ -519,25 +354,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "24e8bacf-700c-4139-b50f-c98a750c8ebd",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/n8/sbp8v1ys5wz6pm1xg3jkgnpm0000gn/T/ipykernel_23685/1657412487.py:1: DeprecationWarning: output_component_file parameter is deprecated and will eventually be removed. Please use `Compiler().compile()` to compile a component instead.\n",
-      "  @component(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "@component(\n",
     "    base_image=BASE_IMAGE,\n",
-    "    output_component_file=\"model_training.yaml\"\n",
     ")\n",
     "def train_busyness(\n",
     "    dataset_train: Input[Dataset],\n",
@@ -598,25 +423,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "id": "b5030b66-2e40-4215-b41f-3ffe598f2df5",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/n8/sbp8v1ys5wz6pm1xg3jkgnpm0000gn/T/ipykernel_23685/2105362814.py:1: DeprecationWarning: output_component_file parameter is deprecated and will eventually be removed. Please use `Compiler().compile()` to compile a component instead.\n",
-      "  @component(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "@component(\n",
     "    base_image=BASE_IMAGE,\n",
-    "    output_component_file=\"model_evaluation.yaml\"\n",
     ")\n",
     "def evaluate_busyness(\n",
     "    busyness_model: Input[Model],\n",
@@ -653,26 +468,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "id": "c7a26372-9e07-4edc-9fc0-2a7188aab032",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/var/folders/n8/sbp8v1ys5wz6pm1xg3jkgnpm0000gn/T/ipykernel_23685/1137965636.py:1: DeprecationWarning: output_component_file parameter is deprecated and will eventually be removed. Please use `Compiler().compile()` to compile a component instead.\n",
-      "  @component(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "@component(\n",
     "    base_image=BASE_IMAGE,\n",
     "    install_kfp_package=False,\n",
-    "    output_component_file=\"model_deployment.yaml\",\n",
     ")\n",
     "def deploy_busyness(\n",
     "        serving_container_image_uri: str,\n",
@@ -763,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "id": "d3559983-00bd-4b73-9085-af190b67950b",
    "metadata": {
     "tags": []
@@ -777,7 +582,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "id": "9365f534-c885-431e-9ac5-3f04c52bbd5e",
    "metadata": {
     "tags": []
@@ -832,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "id": "648d586c-a063-4413-a898-87fc4cdd5bf5",
    "metadata": {},
    "outputs": [],
@@ -845,7 +650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "id": "d9e1f920-c0a0-40a7-9827-58d15a70a97b",
    "metadata": {},
    "outputs": [],
@@ -862,44 +667,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": null,
    "id": "4f8dd691-60b6-464e-ada5-095d3d37f303",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating PipelineJob\n",
-      "PipelineJob created. Resource name: projects/311923924433/locations/us-central1/pipelineJobs/pipeline-rb-20240117104617\n",
-      "To use this PipelineJob in another session:\n",
-      "pipeline_job = aiplatform.PipelineJob.get('projects/311923924433/locations/us-central1/pipelineJobs/pipeline-rb-20240117104617')\n",
-      "View Pipeline Job:\n",
-      "https://console.cloud.google.com/vertex-ai/locations/us-central1/pipelines/runs/pipeline-rb-20240117104617?project=311923924433\n",
-      "PipelineJob projects/311923924433/locations/us-central1/pipelineJobs/pipeline-rb-20240117104617 current state:\n",
-      "3\n",
-      "PipelineJob projects/311923924433/locations/us-central1/pipelineJobs/pipeline-rb-20240117104617 current state:\n",
-      "3\n",
-      "PipelineJob projects/311923924433/locations/us-central1/pipelineJobs/pipeline-rb-20240117104617 current state:\n",
-      "3\n"
-     ]
-    },
-    {
-     "ename": "RuntimeError",
-     "evalue": "Job failed with:\ncode: 9\nmessage: \"The DAG failed because some tasks failed. The failed tasks are: [get-std-data].; Job (project_id = id-410816, job_id = 4861649266763890688) is failed due to the above error.; Failed to handle the job: {project_number = 311923924433, job_id = 4861649266763890688}\"\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[66], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# RUN THE PIPELINE\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m \u001b[43mstart_pipeline\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/miniconda3/envs/STD/lib/python3.11/site-packages/google/cloud/aiplatform/pipeline_jobs.py:323\u001b[0m, in \u001b[0;36mPipelineJob.run\u001b[0;34m(self, service_account, network, reserved_ip_ranges, sync, create_request_timeout)\u001b[0m\n\u001b[1;32m    301\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Run this configured PipelineJob and monitor the job until completion.\u001b[39;00m\n\u001b[1;32m    302\u001b[0m \n\u001b[1;32m    303\u001b[0m \u001b[38;5;124;03mArgs:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    319\u001b[0m \u001b[38;5;124;03m        Optional. The timeout for the create request in seconds.\u001b[39;00m\n\u001b[1;32m    320\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    321\u001b[0m network \u001b[38;5;241m=\u001b[39m network \u001b[38;5;129;01mor\u001b[39;00m initializer\u001b[38;5;241m.\u001b[39mglobal_config\u001b[38;5;241m.\u001b[39mnetwork\n\u001b[0;32m--> 323\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_run\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    324\u001b[0m \u001b[43m    \u001b[49m\u001b[43mservice_account\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mservice_account\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    325\u001b[0m \u001b[43m    \u001b[49m\u001b[43mnetwork\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mnetwork\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    326\u001b[0m \u001b[43m    \u001b[49m\u001b[43mreserved_ip_ranges\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mreserved_ip_ranges\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    327\u001b[0m \u001b[43m    \u001b[49m\u001b[43msync\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43msync\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    328\u001b[0m \u001b[43m    \u001b[49m\u001b[43mcreate_request_timeout\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcreate_request_timeout\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    329\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/miniconda3/envs/STD/lib/python3.11/site-packages/google/cloud/aiplatform/base.py:817\u001b[0m, in \u001b[0;36moptional_sync.<locals>.optional_run_in_thread.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    815\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m:\n\u001b[1;32m    816\u001b[0m         VertexAiResourceNounWithFutureManager\u001b[38;5;241m.\u001b[39mwait(\u001b[38;5;28mself\u001b[39m)\n\u001b[0;32m--> 817\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mmethod\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    819\u001b[0m \u001b[38;5;66;03m# callbacks to call within the Future (in same Thread)\u001b[39;00m\n\u001b[1;32m    820\u001b[0m internal_callbacks \u001b[38;5;241m=\u001b[39m []\n",
-      "File \u001b[0;32m~/miniconda3/envs/STD/lib/python3.11/site-packages/google/cloud/aiplatform/pipeline_jobs.py:366\u001b[0m, in \u001b[0;36mPipelineJob._run\u001b[0;34m(self, service_account, network, reserved_ip_ranges, sync, create_request_timeout)\u001b[0m\n\u001b[1;32m    340\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"Helper method to ensure network synchronization and to run\u001b[39;00m\n\u001b[1;32m    341\u001b[0m \u001b[38;5;124;03mthe configured PipelineJob and monitor the job until completion.\u001b[39;00m\n\u001b[1;32m    342\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    357\u001b[0m \u001b[38;5;124;03m        Optional. The timeout for the create request in seconds.\u001b[39;00m\n\u001b[1;32m    358\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    359\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msubmit(\n\u001b[1;32m    360\u001b[0m     service_account\u001b[38;5;241m=\u001b[39mservice_account,\n\u001b[1;32m    361\u001b[0m     network\u001b[38;5;241m=\u001b[39mnetwork,\n\u001b[1;32m    362\u001b[0m     reserved_ip_ranges\u001b[38;5;241m=\u001b[39mreserved_ip_ranges,\n\u001b[1;32m    363\u001b[0m     create_request_timeout\u001b[38;5;241m=\u001b[39mcreate_request_timeout,\n\u001b[1;32m    364\u001b[0m )\n\u001b[0;32m--> 366\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_block_until_complete\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/miniconda3/envs/STD/lib/python3.11/site-packages/google/cloud/aiplatform/pipeline_jobs.py:615\u001b[0m, in \u001b[0;36mPipelineJob._block_until_complete\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    612\u001b[0m \u001b[38;5;66;03m# Error is only populated when the job state is\u001b[39;00m\n\u001b[1;32m    613\u001b[0m \u001b[38;5;66;03m# JOB_STATE_FAILED or JOB_STATE_CANCELLED.\u001b[39;00m\n\u001b[1;32m    614\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_gca_resource\u001b[38;5;241m.\u001b[39mstate \u001b[38;5;129;01min\u001b[39;00m _PIPELINE_ERROR_STATES:\n\u001b[0;32m--> 615\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mRuntimeError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mJob failed with:\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[38;5;132;01m%s\u001b[39;00m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m%\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_gca_resource\u001b[38;5;241m.\u001b[39merror)\n\u001b[1;32m    616\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    617\u001b[0m     _LOGGER\u001b[38;5;241m.\u001b[39mlog_action_completed_against_resource(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mrun\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcompleted\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28mself\u001b[39m)\n",
-      "\u001b[0;31mRuntimeError\u001b[0m: Job failed with:\ncode: 9\nmessage: \"The DAG failed because some tasks failed. The failed tasks are: [get-std-data].; Job (project_id = id-410816, job_id = 4861649266763890688) is failed due to the above error.; Failed to handle the job: {project_number = 311923924433, job_id = 4861649266763890688}\"\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# RUN THE PIPELINE\n",
     "\n",
@@ -966,6 +737,22 @@
    "source": [
     "print(predictions)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from kfp import compiler\n",
+    "\n",
+    "compiler.Compiler().compile(get_std_data, package_path='get_data.yaml')\n",
+    "compiler.Compiler().compile(preprocess_std_data, package_path='preprocessing.yaml')\n",
+    "compiler.Compiler().compile(train_test_split, package_path='train_test_split.yaml')\n",
+    "compiler.Compiler().compile(train_busyness, package_path='model_training.yaml')\n",
+    "compiler.Compiler().compile(evaluate_busyness, package_path='model_evaluation.yaml')\n",
+    "compiler.Compiler().compile(deploy_busyness, package_path='model_deployment.yaml')\n"
+   ],
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- remove deprecated `output_component_file` from all `@component` decorators in `vertex_ai_pipeline.ipynb`
- add a dedicated step using `compiler.Compiler().compile` to generate component YAMLs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689261400a94832fa3f87b07b06f2e55