### PR TITLE
feat: add bigquery data loading and model caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ google-api-core==2.17.1
 google-auth==2.29.0
 google-cloud-aiplatform==1.49.0
 google-cloud-bigquery==3.17.2
+google-cloud-bigquery-storage==2.25.0
 google-cloud-core==2.4.1
 google-cloud-resource-manager==1.12.1
 google-cloud-storage==2.16.0

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -10,4 +10,4 @@ COPY src /app/src
 
 RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
-CMD exec gunicorn --bind :$AIP_HTTP_PORT --log-level info --workers 1 --timeout 90 app:app
+CMD exec gunicorn --bind :$AIP_HTTP_PORT --log-level info --workers ${GUNICORN_WORKERS:-1} --timeout 90 app:app

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the project."""
+
+from .bigquery import read_bigquery
+
+__all__ = ["read_bigquery"]

--- a/utils/bigquery.py
+++ b/utils/bigquery.py
@@ -1,0 +1,27 @@
+"""Utilities for loading data from BigQuery."""
+
+from __future__ import annotations
+
+import pandas as pd
+from google.cloud import bigquery
+
+
+def read_bigquery(query: str, project_id: str) -> pd.DataFrame:
+    """Execute ``query`` against ``project_id`` and return a DataFrame.
+
+    Parameters
+    ----------
+    query: str
+        SQL query to execute in BigQuery.
+    project_id: str
+        Google Cloud project that hosts the BigQuery dataset.
+
+    Returns
+    -------
+    pd.DataFrame
+        Query results as a DataFrame. Uses the BigQuery Storage API when
+        available which offers better performance on large result sets.
+    """
+    client = bigquery.Client(project=project_id)
+    job = client.query(query)
+    return job.result().to_dataframe(create_bqstorage_client=True)


### PR DESCRIPTION
## Summary
- add utility to load training data from BigQuery using the storage API
- allow main pipeline to read from BigQuery via environment variables
- cache model in server and support configurable gunicorn workers

## Testing
- `pytest`
- `pre-commit run --files main.py utils/bigquery.py utils/__init__.py server/app.py server/Dockerfile requirements.txt` *(command failed: pre-commit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68926384b034832f80ad531470a04309